### PR TITLE
Update to Laravel 13

### DIFF
--- a/.github/workflows/format_php.yml
+++ b/.github/workflows/format_php.yml
@@ -10,25 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: curl, mbstring, pdo, bcmath, intl
           coverage: none
 
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v1
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             ${{ runner.os }}-composer-
 
@@ -40,7 +40,7 @@ jobs:
         run: |
           PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix
 
-      - uses: stefanzweifel/git-auto-commit-action@v4.2.0
+      - uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
           commit_message: Apply php-cs-fixer changes (skipci)
           branch: ${{ github.head_ref }}

--- a/.github/workflows/format_php.yml
+++ b/.github/workflows/format_php.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           extensions: curl, mbstring, pdo, bcmath, intl
           coverage: none
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run cs-fixer
         run: |
-          PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix
+          vendor/bin/php-cs-fixer fix
 
       - uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:

--- a/.github/workflows/run_static_analysis.yml
+++ b/.github/workflows/run_static_analysis.yml
@@ -12,20 +12,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: curl, mbstring, pdo, bcmath
           coverage: none
 
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v1
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/run_static_analysis.yml
+++ b/.github/workflows/run_static_analysis.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           extensions: curl, mbstring, pdo, bcmath
           coverage: none
 

--- a/.github/workflows/run_static_analysis.yml
+++ b/.github/workflows/run_static_analysis.yml
@@ -3,6 +3,9 @@ name: Run static analysis
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   php-static-analysis:
     if: "!contains(github.event.head_commit.message, 'skipci')"
@@ -13,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,6 +2,9 @@ name: Run tests
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skipci')"
@@ -17,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,12 +10,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skipci')"
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.3', '8.4', '8.5']
-
-    name: Run tests (PHP ${{ matrix.php }})
+    name: Run tests
 
     steps:
       - name: Checkout code
@@ -26,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: 8.5
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
           coverage: none
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,17 +7,22 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skipci')"
     runs-on: ubuntu-latest
 
-    name: Run tests
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+
+    name: Run tests (PHP ${{ matrix.php }})
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
           coverage: none
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ The transaction model would look like:
 use LenderSpender\StateTransitionWorkflow\HasStateTransitions;
 
 /**
- * @property \App\Enums\TransactionState $state
+ * @property \App\Enums\TransactionState $status
  */
 class Transaction extends Model
 {
     use HasStateTransitions;
 
-    protected function registerStateTransitions(): void
+    protected static function registerStateTransitions(): void
     {
-        $this->addState('status')
-            ->allowTransition(TransactionState::CREATED(), TransactionState::SUCCESS(), TransactionSuccessfullWorkflow::class)
-            ->allowTransition(TransactionState::CREATED(), TransactionState::FAILED());
+        static::addState('status')
+            ->allowTransition(TransactionState::CREATED, TransactionState::SUCCESS, TransactionSuccessfullWorkflow::class)
+            ->allowTransition(TransactionState::CREATED, TransactionState::FAILED);
     }
 }
 ```
@@ -33,19 +33,18 @@ class Transaction extends Model
 Here is what the TransactionState enum looks like:
 
 ```php
-use LenderSpender\LaravelEnums\Enum;
 use LenderSpender\StateTransitionWorkflow\TransitionState;
 
-/**
- * @method static self CREATED()
- * @method static self SUCCESS()
- * @method static self FAILED()
- */
-class FooStates extends Enum implements TransitionState
+enum TransactionState: string implements TransitionState
 {
-    private const CREATED = 'created';
-    private const SUCCESS = 'success';
-    private const FAILED = 'failed';
+    case CREATED = 'created';
+    case SUCCESS = 'success';
+    case FAILED = 'failed';
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
 }
 ```
 
@@ -77,9 +76,9 @@ And here is how you use it:
 
 ```php
 $transaction = Transaction::find(1337);
-$transaction->transitionStateTo(FooStates::SUCCESS());
+$transaction->transitionStateTo(TransactionState::SUCCESS);
 
-$transaction->state == FooStates::SUCCESS; // true
+$transaction->status === TransactionState::SUCCESS; // true
 ```
 
 
@@ -91,6 +90,29 @@ You can install the package via composer:
 ```bash
 composer require lenderspender/laravel-state-transition-workflow
 ```
+
+## Upgrading to 5.0
+
+Transitions are now registered statically, so the reflection-based instantiation that used to happen during Laravel's model boot cycle is gone. Two mechanical changes are needed in every model using the trait:
+
+```php
+// 4.x
+protected function registerStateTransitions(): void
+{
+    $this->addState('status')
+        ->allowTransition(State::CREATED, State::SUCCESS);
+}
+
+// 5.x
+protected static function registerStateTransitions(): void
+{
+    static::addState('status')
+        ->allowTransition(State::CREATED, State::SUCCESS);
+}
+```
+
+1. Add `static` to `registerStateTransitions()`.
+2. Replace `$this->addState(...)` with `static::addState(...)`.
 
 ## Usage
 
@@ -107,15 +129,15 @@ use Illuminate\Database\Eloquent\Model;
 use LenderSpender\StateTransitionWorkflow\HasStateTransitions;
 
 /**
- * @property \App\Enums\TransactionState $state
+ * @property \App\Enums\TransactionState $status
  */
 class Transaction extends Model
 {
     use HasStateTransitions;
 
-    protected function registerStateTransitions(): void
+    protected static function registerStateTransitions(): void
     {
-        $this->addState('status');
+        static::addState('status');
     }
 }
 ```
@@ -126,22 +148,22 @@ Transitions are used to transition the state field for a model from one to anoth
 You need to specify which transitions are allowed and what workflow should be started on transition.
 By default all transitions are not allowed, to allow transitions you should call `allowTransition` on the added state.
 
-Single transition from `State::FROM()` to `State::TO()`
+Single transition from `State::FROM` to `State::TO`
 
 ```php
 class Transaction extends Model
 {
     use HasStateTransitions;
 
-    protected function registerStateTransitions(): void
+    protected static function registerStateTransitions(): void
     {
-        $this->addState('status')
-            ->allowTransitions(State::FROM(), State::TO());
+        static::addState('status')
+            ->allowTransition(State::FROM, State::TO);
     }
 }
 ```
 
-Allow transitions from `State::CREATED()` to `State::FAILED()` and `State::SUCCESS()`
+Allow transitions from `State::CREATED` to `State::FAILED` and `State::SUCCESS`
 
 ```php
 use Illuminate\Database\Eloquent\Model;
@@ -151,15 +173,15 @@ class Transaction extends Model
 {
     use HasStateTransitions;
 
-    protected function registerStateTransitions(): void
+    protected static function registerStateTransitions(): void
     {
-        $this->addState('status')
-            ->allowTransitions(State::CREATED(), [State::FAILED(), State::SUCCESS());
+        static::addState('status')
+            ->allowTransition(State::CREATED, [State::FAILED, State::SUCCESS]);
     }
 }        
 ```
 
-Allow transitions from `State::CREATED()` and `State::UPDATED()` to `State::FAILED()` and `State::SUCCESS()`
+Allow transitions from `State::CREATED` and `State::UPDATED` to `State::FAILED` and `State::SUCCESS`
 
 ```php
 use LenderSpender\StateTransitionWorkflow\HasStateTransitions;
@@ -168,10 +190,10 @@ class Transaction extends Model
 {
     use HasStateTransitions;
 
-    protected function registerStateTransitions(): void
+    protected static function registerStateTransitions(): void
     {
-        $this->addState('status')
-            ->allowTransitions([State::CREATED(), State::UPDATED()], [State::FAILED(), State::SUCCESS()]);
+        static::addState('status')
+            ->allowTransition([State::CREATED, State::UPDATED], [State::FAILED, State::SUCCESS]);
     }
 }
 ```
@@ -181,13 +203,13 @@ class Transaction extends Model
 Transitions can be used by calling the `transitionStateTo` method on the model.
 
 ```php
-$transaction->transitionStateTo(State::SUCCESS());
+$transaction->transitionStateTo(State::SUCCESS);
 ```
 
 By default the method uses the first registered state. When you've added multiple state fields you should specify which field to use.
 
 ```php
-$transaction->transitionStateTo(State::SUCCESS(), 'status');
+$transaction->transitionStateTo(State::SUCCESS, 'status');
 ```
 
 When a state transitions is not allowed a `LenderSpender\StateTransitionWorkflow\Exceptions\TransitionNotAllowedException` is thrown.
@@ -290,10 +312,10 @@ class Transaction extends Model
 {
     use HasStateTransitions;
 
-    protected function registerStateTransitions(): void
+    protected static function registerStateTransitions(): void
     {
-        $this->addState('status')
-            ->allowTransitions(State::CREATED(), State::SUCCESS(), PaidWorkflow::class);
+        static::addState('status')
+            ->allowTransition(State::CREATED, State::SUCCESS, PaidWorkflow::class);
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
         }
     },
     "require": {
-        "php": "^8.2",
-        "laravel/framework": "^12.0 | ^11.0 | ^10.0",
-        "spatie/laravel-queueable-action": "^2.14"
+        "php": "^8.3",
+        "laravel/framework": "^13.0",
+        "spatie/laravel-queueable-action": "^2.17"
     },
     "require-dev": {
         "lenderspender/php-cs-fixer-rules": "dev-master",
-        "orchestra/testbench": "^10.0",
-        "phpstan/phpstan": "^1.3.1",
-        "phpunit/phpunit": "^11.0"
+        "orchestra/testbench": "^11.0",
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^12.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "laravel/framework": "^13.0",
         "spatie/laravel-queueable-action": "^2.17"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Test Suite">
       <directory>tests</directory>

--- a/src/HasStateTransitions.php
+++ b/src/HasStateTransitions.php
@@ -7,7 +7,7 @@ namespace LenderSpender\StateTransitionWorkflow;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Attributes\Boot;
 use LenderSpender\StateTransitionWorkflow\Exceptions\TransitionNotAllowedException;
-use UnexpectedValueException;
+
 use function PHPUnit\Framework\assertInstanceOf;
 
 trait HasStateTransitions
@@ -90,7 +90,8 @@ trait HasStateTransitions
         $state = $this->{$field};
 
         assertInstanceOf(
-            TransitionState::class, $state,
+            TransitionState::class,
+            $state,
             sprintf('State field [%s] on [%s] must hold a %s, %s given.', $field, static::class, TransitionState::class, get_debug_type($state))
         );
 

--- a/src/HasStateTransitions.php
+++ b/src/HasStateTransitions.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Attributes\Boot;
 use LenderSpender\StateTransitionWorkflow\Exceptions\TransitionNotAllowedException;
 use UnexpectedValueException;
+use function PHPUnit\Framework\assertInstanceOf;
 
 trait HasStateTransitions
 {
@@ -88,9 +89,10 @@ trait HasStateTransitions
     {
         $state = $this->{$field};
 
-        if (! $state instanceof TransitionState) {
-            throw new UnexpectedValueException(sprintf('State field [%s] on [%s] must hold a %s, %s given.', $field, static::class, TransitionState::class, get_debug_type($state)));
-        }
+        assertInstanceOf(
+            TransitionState::class, $state,
+            sprintf('State field [%s] on [%s] must hold a %s, %s given.', $field, static::class, TransitionState::class, get_debug_type($state))
+        );
 
         return $state;
     }

--- a/src/HasStateTransitions.php
+++ b/src/HasStateTransitions.php
@@ -89,8 +89,8 @@ trait HasStateTransitions
     {
         $state = $this->{$field};
 
-        assertInstanceOf(
-            TransitionState::class, $state,
+        assert(
+            TransitionState::class instanceof $state,
             sprintf('State field [%s] on [%s] must hold a %s, %s given.', $field, static::class, TransitionState::class, get_debug_type($state))
         );
 

--- a/src/HasStateTransitions.php
+++ b/src/HasStateTransitions.php
@@ -88,7 +88,7 @@ trait HasStateTransitions
         $state = $this->{$field};
 
         assert(
-            TransitionState::class instanceof $state,
+            $state instanceof TransitionState,
             sprintf('State field [%s] on [%s] must hold a %s, %s given.', $field, static::class, TransitionState::class, get_debug_type($state))
         );
 

--- a/src/HasStateTransitions.php
+++ b/src/HasStateTransitions.php
@@ -5,18 +5,28 @@ declare(strict_types=1);
 namespace LenderSpender\StateTransitionWorkflow;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Attributes\Boot;
 use LenderSpender\StateTransitionWorkflow\Exceptions\TransitionNotAllowedException;
-use ReflectionClass;
+use UnexpectedValueException;
 
 trait HasStateTransitions
 {
     /** @var TransitionWorkflowConfig[] */
     protected static array $stateFields = [];
 
+    #[Boot]
     public static function bootHasStateTransitions(): void
     {
-        $class = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
-        $class->registerStateTransitions();
+        static::registerStateTransitions();
+    }
+
+    protected static function addState(string $field): TransitionWorkflowConfig
+    {
+        $stateConfig = new TransitionWorkflowConfig($field);
+
+        static::$stateFields[$field] = $stateConfig;
+
+        return $stateConfig;
     }
 
     public function transitionStateTo(TransitionState $to, ?string $field = null): self
@@ -24,7 +34,7 @@ trait HasStateTransitions
         $transitionWorkflowConfig = $this->getTransitionWorkflowConfig($field);
 
         $field = $transitionWorkflowConfig->field;
-        $transition = new Transition($this, $field, $this->{$field}, $to);
+        $transition = new Transition($this, $field, $this->getState($field), $to);
         $workflow = $transitionWorkflowConfig->getWorkflow($transition);
 
         if (! $workflow || ! $workflow->isAllowed($transition)) {
@@ -51,7 +61,7 @@ trait HasStateTransitions
     {
         $transitionWorkflowConfig = $this->getTransitionWorkflowConfig($field);
 
-        $currentState = $this->{$transitionWorkflowConfig->field};
+        $currentState = $this->getState($transitionWorkflowConfig->field);
 
         return array_values(array_map(function (array $transitions) {
             return $transitions['to'];
@@ -63,19 +73,25 @@ trait HasStateTransitions
         return in_array($state, $this->getAvailableStateTransitions($field));
     }
 
-    protected function addState(string $field): TransitionWorkflowConfig
-    {
-        $stateConfig = new TransitionWorkflowConfig($field);
-
-        static::$stateFields[$field] = $stateConfig;
-
-        return $stateConfig;
-    }
-
-    abstract protected function registerStateTransitions(): void;
+    abstract protected static function registerStateTransitions(): void;
 
     private function getTransitionWorkflowConfig(?string $field): TransitionWorkflowConfig
     {
-        return static::$stateFields[$field] ?? array_values(static::$stateFields)[0];
+        if ($field !== null && isset(static::$stateFields[$field])) {
+            return static::$stateFields[$field];
+        }
+
+        return array_values(static::$stateFields)[0];
+    }
+
+    private function getState(string $field): TransitionState
+    {
+        $state = $this->{$field};
+
+        if (! $state instanceof TransitionState) {
+            throw new UnexpectedValueException(sprintf('State field [%s] on [%s] must hold a %s, %s given.', $field, static::class, TransitionState::class, get_debug_type($state)));
+        }
+
+        return $state;
     }
 }

--- a/src/HasStateTransitions.php
+++ b/src/HasStateTransitions.php
@@ -7,8 +7,6 @@ namespace LenderSpender\StateTransitionWorkflow;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Attributes\Boot;
 use LenderSpender\StateTransitionWorkflow\Exceptions\TransitionNotAllowedException;
-use UnexpectedValueException;
-use function PHPUnit\Framework\assertInstanceOf;
 
 trait HasStateTransitions
 {

--- a/tests/Stubs/TransitionableModel.php
+++ b/tests/Stubs/TransitionableModel.php
@@ -23,6 +23,17 @@ class TransitionableModel extends Model
         'status' => FooStates::class,
     ];
 
+    protected static function registerStateTransitions(): void
+    {
+        static::addState('status')
+            ->allowTransition(FooStates::FIRST, FooStates::SECOND)
+            ->allowTransition(FooStates::SECOND, [FooStates::FIRST, FooStates::WITH_CUSTOM_WORKFLOW_CLASS])
+            ->allowTransition([FooStates::MULTIPLE1, FooStates::MULTIPLE2], [FooStates::FIRST, FooStates::SECOND])
+            ->allowTransition(FooStates::FIRST, FooStates::WITH_CUSTOM_WORKFLOW_CLASS, CustomWorkflow::class)
+            ->allowTransition(FooStates::FIRST, FooStates::WITH_CUSTOM_QUEUED_WORKFLOW_CLASS, CustomQueuedWorkflow::class)
+            ->allowTransition(FooStates::FIRST, FooStates::WITH_DENIED_WORKFLOW_CLASS, DeniedWorkflow::class);
+    }
+
     /**
      * @param array<string, mixed> $attributes
      * @param array<string, mixed> $options
@@ -40,16 +51,5 @@ class TransitionableModel extends Model
     public function save(array $options = []): bool
     {
         return true;
-    }
-
-    protected function registerStateTransitions(): void
-    {
-        $this->addState('status')
-            ->allowTransition(FooStates::FIRST, FooStates::SECOND)
-            ->allowTransition(FooStates::SECOND, [FooStates::FIRST, FooStates::WITH_CUSTOM_WORKFLOW_CLASS])
-            ->allowTransition([FooStates::MULTIPLE1, FooStates::MULTIPLE2], [FooStates::FIRST, FooStates::SECOND])
-            ->allowTransition(FooStates::FIRST, FooStates::WITH_CUSTOM_WORKFLOW_CLASS, CustomWorkflow::class)
-            ->allowTransition(FooStates::FIRST, FooStates::WITH_CUSTOM_QUEUED_WORKFLOW_CLASS, CustomQueuedWorkflow::class)
-            ->allowTransition(FooStates::FIRST, FooStates::WITH_DENIED_WORKFLOW_CLASS, DeniedWorkflow::class);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * State transition registration now uses static configuration and native Laravel bootstrapping.
  * State access is validated consistently, with clear errors for invalid state values.

* **Documentation**
  * Updated examples for Laravel State Transitions v5, including native enums, `status`, and transition registration.
  * Added an upgrade guide covering required registration changes.

* **Chores**
  * Updated supported PHP and Laravel versions and refreshed testing and analysis tooling.
  * CI now tests PHP 8.3, 8.4, and 8.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->